### PR TITLE
place dudle directly into webroot

### DIFF
--- a/etc/apache2/sites-available/001-dudle.conf
+++ b/etc/apache2/sites-available/001-dudle.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:80>
 
 	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
+	DocumentRoot /var/www/html/dudle
 
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined


### PR DESCRIPTION
Hi, I made a little change to the VirtualHost config file. Now the dudle application lives directly in the webroot. To me, this is more natural as I access the app on a separate subdomain. Before the change, I would get an Apache information page in the webroot.
